### PR TITLE
Add basic templating ability in plugin settings

### DIFF
--- a/sentry_telegram/plugin.py
+++ b/sentry_telegram/plugin.py
@@ -24,7 +24,7 @@ class TelegramNotificationsOptionsForm(notify.NotificationConfigurationForm):
 
     message_template = forms.CharField(
         label=_('Message template'),
-        widget=forms.TextInput(),
+        widget=forms.Textarea(attrs={'class': 'span4'}),
         help_text=_('Set in standard python\'s {}-format convention, available names are: '
                     '{project_name}, {url}, {title}, {message}, {tag[%your_tag%]}'),
         initial='*[Sentry]* {project_name} {tag[level]}: *{title}*\n\n{message}\n\n{url}'
@@ -96,7 +96,7 @@ class TelegramNotificationsPlugin(notify.NotificationPlugin):
 
         template = self.get_message_template(group.project)
 
-        text = template.format_map(names)
+        text = template.format(**names)
 
         return {
             'text': text,

--- a/sentry_telegram/plugin.py
+++ b/sentry_telegram/plugin.py
@@ -75,7 +75,7 @@ class TelegramNotificationsPlugin(notify.NotificationPlugin):
             {
                 'name': 'message_template',
                 'label': 'Message Template',
-                'type': 'text',
+                'type': 'textarea',
                 'help': 'Set in standard python\'s {}-format convention, available names are: '
                     '{project_name}, {url}, {title}, {message}, {tag[%your_tag%]}',
                 'validators': [],

--- a/sentry_telegram/plugin.py
+++ b/sentry_telegram/plugin.py
@@ -22,6 +22,14 @@ class TelegramNotificationsOptionsForm(notify.NotificationConfigurationForm):
         widget=forms.Textarea(attrs={'class': 'span6'}),
         help_text=_('Enter receivers IDs (one per line). Personal messages, group chats and channels also available.'))
 
+    message_template = forms.CharField(
+        label=_('Message template'),
+        widget=forms.TextInput(),
+        help_text=_('Set in standard python\'s {}-format convention, available names are: '
+                    '{project_name}, {url}, {title}, {message}, {tag[%your_tag%]}'),
+        initial='*[Sentry]* {project_name} {tag[level]}: *{title}*\n\n{message}\n\n{url}'
+    )
+
 
 class TelegramNotificationsPlugin(notify.NotificationPlugin):
     title = 'Telegram Notifications'
@@ -64,14 +72,32 @@ class TelegramNotificationsPlugin(notify.NotificationPlugin):
                 'validators': [],
                 'required': True,
             },
+            {
+                'name': 'message_template',
+                'label': 'Message Template',
+                'type': 'text',
+                'help': 'Set in standard python\'s {}-format convention, available names are: '
+                    '{project_name}, {url}, {title}, {message}, {tag[%your_tag%]}',
+                'validators': [],
+                'required': True,
+                'default': '*[Sentry]* {project_name} {tag[level]}: *{title}*\n\n{message}\n\n{url}'
+            },
         ]
 
     def build_message(self, group, event):
-        text = '*[Sentry]* {project_name} {level}\n{url}'.format(**{
+
+        names = {
+            'title': event.title,
+            'tag': {k:v for k, v in event.tags},
+            'message': event.message,
             'project_name': group.project.name,
-            'level': event.get_tag('level'),
             'url': group.get_absolute_url(),
-        })
+        }
+
+        template = self.get_message_template(group.project)
+
+        text = template.format_map(names)
+
         return {
             'text': text,
             'parse_mode': 'Markdown',
@@ -79,6 +105,9 @@ class TelegramNotificationsPlugin(notify.NotificationPlugin):
 
     def build_url(self, project):
         return 'https://api.telegram.org/bot%s/sendMessage' % self.get_option('api_token', project)
+
+    def get_message_template(self, project):
+        return self.get_option('message_template', project)
 
     def get_receivers(self, project):
         receivers = self.get_option('receivers', project)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,9 +1,12 @@
 # coding: utf-8
 from mock import call, patch
+import pytest
 
+import sentry
 from sentry.plugins import plugins, Notification
 from sentry.testutils import PluginTestCase
 from sentry.utils.samples import create_sample_event
+
 
 from sentry_telegram import TelegramNotificationsPlugin
 
@@ -18,10 +21,13 @@ class BaseTest(PluginTestCase):
     def test_is_registered(self):
         assert plugins.get('sentry_telegram').slug == self.plugin.slug
 
-    def test_complex_send_notification(self):
+    @pytest.mark.skipif(not sentry.__version__.startswith('8.9.0'), reason="sentry versions newer than 8.9.0 message text is longer than title")
+    def test_old_complex_send_notification(self):
         self.initialized_plugin.set_option('receivers', '123', self.project)
         self.initialized_plugin.set_option('api_token', 'api:token', self.project)
-        self.initialized_plugin.set_option('message_template', '*[Sentry]* {project_name} {tag[level]}: {title}\n{message}\n{url}', self.project)
+        self.initialized_plugin.set_option('message_template',
+                                           '*[Sentry]* {project_name} {tag[level]}: {title}\n{message}\n{url}',
+                                           self.project)
         event = create_sample_event(self.project, platform='python')
         notification = Notification(event=event)
         with patch('requests.sessions.Session.request') as request:
@@ -32,7 +38,32 @@ class BaseTest(PluginTestCase):
                     method='POST',
                     headers={'Content-Type': 'application/json'},
                     url=u'https://api.telegram.org/botapi:token/sendMessage',
-                    json={'text': '*[Sentry]* Bar error: This is an example python exception\nThis is an example python exception\nhttp://testserver/baz/bar/issues/1/', 'parse_mode': 'Markdown', 'chat_id': '123'},
+                    json={'text': u'*[Sentry]* Bar error: This is an example python exception\nThis is an example python exception\nhttp://testserver/baz/bar/issues/1/', 'parse_mode': 'Markdown', 'chat_id': '123'},
+                    timeout=30,
+                    verify=True,
+                ),
+            ]
+
+    @pytest.mark.skipif(sentry.__version__.startswith('8.9.0'), reason="sentry 8.9.0 message text equals to title")
+    def test_complex_send_notification(self):
+        self.initialized_plugin.set_option('receivers', '123', self.project)
+        self.initialized_plugin.set_option('api_token', 'api:token', self.project)
+        self.initialized_plugin.set_option('message_template',
+                                           '*[Sentry]* {project_name} {tag[level]}: {title}\n{message}\n{url}',
+                                           self.project)
+        event = create_sample_event(self.project, platform='python')
+        notification = Notification(event=event)
+        with patch('requests.sessions.Session.request') as request:
+            self.initialized_plugin.notify(notification)
+            assert request.call_args_list == [
+                call(
+                    allow_redirects=False,
+                    method='POST',
+                    headers={'Content-Type': 'application/json'},
+                    url=u'https://api.telegram.org/botapi:token/sendMessage',
+                    json={
+                        'text': u'*[Sentry]* Bar error: This is an example python exception\nThis is an example python exception raven.scripts.runner in main\nhttp://testserver/baz/bar/issues/1/',
+                        'parse_mode': 'Markdown', 'chat_id': '123'},
                     timeout=30,
                     verify=True,
                 ),

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -21,6 +21,7 @@ class BaseTest(PluginTestCase):
     def test_complex_send_notification(self):
         self.initialized_plugin.set_option('receivers', '123', self.project)
         self.initialized_plugin.set_option('api_token', 'api:token', self.project)
+        self.initialized_plugin.set_option('message_template', '*[Sentry]* {project_name} {tag[level]}: {title}\n{message}\n{url}', self.project)
         event = create_sample_event(self.project, platform='python')
         notification = Notification(event=event)
         with patch('requests.sessions.Session.request') as request:
@@ -31,7 +32,7 @@ class BaseTest(PluginTestCase):
                     method='POST',
                     headers={'Content-Type': 'application/json'},
                     url=u'https://api.telegram.org/botapi:token/sendMessage',
-                    json={'text': '*[Sentry]* Bar error\nhttp://testserver/baz/bar/issues/1/', 'parse_mode': 'Markdown', 'chat_id': '123'},
+                    json={'text': '*[Sentry]* Bar error: This is an example python exception\nThis is an example python exception\nhttp://testserver/baz/bar/issues/1/', 'parse_mode': 'Markdown', 'chat_id': '123'},
                     timeout=30,
                     verify=True,
                 ),


### PR DESCRIPTION
I have added some basic templating ability, and threw it onto plugin settings page. It also refers to #6.
Dropped previous pull request because of failed tests. This pull request fixes it. 
