### PR TITLE
set default value for non-existing tags

### DIFF
--- a/sentry_telegram/plugin.py
+++ b/sentry_telegram/plugin.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 import logging
+from collections import defaultdict
 
 from django import forms
 from django.utils.translation import ugettext_lazy as _
@@ -7,7 +8,6 @@ from django.utils.translation import ugettext_lazy as _
 from sentry.plugins.bases import notify
 from sentry.http import safe_urlopen
 from sentry.utils.safe import safe_execute
-from collections import defaultdict
 
 from . import __version__, __doc__ as package_doc
 


### PR DESCRIPTION
If tags set has changed, plugin stops sending notification because of key error. This fixes the problem