### PR TITLE
Added api_origin option

### DIFF
--- a/sentry_telegram/plugin.py
+++ b/sentry_telegram/plugin.py
@@ -56,7 +56,7 @@ class TelegramNotificationsPlugin(notify.NotificationPlugin):
     logger = logging.getLogger('sentry.plugins.sentry_telegram')
 
     def is_configured(self, project, **kwargs):
-        return bool(self.get_option('api_origin', project) and self.get_option('api_token', project) and self.get_option('receivers', project))
+        return bool(self.get_option('api_token', project) and self.get_option('receivers', project))
 
     def get_config(self, project, **kwargs):
         return [
@@ -117,7 +117,7 @@ class TelegramNotificationsPlugin(notify.NotificationPlugin):
         }
 
     def build_url(self, project):
-        return '%s/bot%s/sendMessage' % (self.get_option('api_origin', project),self.get_option('api_token', project))
+        return '%s/bot%s/sendMessage' % (self.get_option('api_origin', project), self.get_option('api_token', project))
 
     def get_message_template(self, project):
         return self.get_option('message_template', project)

--- a/sentry_telegram/plugin.py
+++ b/sentry_telegram/plugin.py
@@ -12,6 +12,11 @@ from . import __version__, __doc__ as package_doc
 
 
 class TelegramNotificationsOptionsForm(notify.NotificationConfigurationForm):
+    api_origin = forms.CharField(
+        label=_('Telegram API origin'),
+        widget=forms.TextInput(attrs={'placeholder': 'https://api.telegram.org'}),
+        initial='https://api.telegram.org'
+    )
     api_token = forms.CharField(
         label=_('BotAPI token'),
         widget=forms.TextInput(attrs={'placeholder': '123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11'}),
@@ -51,10 +56,19 @@ class TelegramNotificationsPlugin(notify.NotificationPlugin):
     logger = logging.getLogger('sentry.plugins.sentry_telegram')
 
     def is_configured(self, project, **kwargs):
-        return bool(self.get_option('api_token', project) and self.get_option('receivers', project))
+        return bool(self.get_option('api_origin', project) and self.get_option('api_token', project) and self.get_option('receivers', project))
 
     def get_config(self, project, **kwargs):
         return [
+            {
+                'name': 'api_origin',
+                'label': 'Telegram API origin',
+                'type': 'text',
+                'placeholder': 'https://api.telegram.org',
+                'validators': [],
+                'required': True,
+                'default': 'https://api.telegram.org'
+            },
             {
                 'name': 'api_token',
                 'label': 'BotAPI token',
@@ -103,7 +117,7 @@ class TelegramNotificationsPlugin(notify.NotificationPlugin):
         }
 
     def build_url(self, project):
-        return 'https://api.telegram.org/bot%s/sendMessage' % self.get_option('api_token', project)
+        return '%s/bot%s/sendMessage' % (self.get_option('api_origin', project),self.get_option('api_token', project))
 
     def get_message_template(self, project):
         return self.get_option('message_template', project)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -30,6 +30,7 @@ class BaseTest(PluginTestCase):
         assert plugins.get('sentry_telegram').slug == self.plugin.slug
 
     def send_notification_helper(self):
+        self.initialized_plugin.set_option('api_origin', 'https://api.telegram.org', self.project)
         self.initialized_plugin.set_option('receivers', '123', self.project)
         self.initialized_plugin.set_option('api_token', 'api:token', self.project)
         self.initialized_plugin.set_option(


### PR DESCRIPTION
An alternative to SOCKS proxy is to make configurable Telegram API origin. It will allow to use nginx reverse-proxy outside of perimether.
#20