### PR TITLE
Proxy support and markdown escaping

### DIFF
--- a/sentry_telegram/plugin.py
+++ b/sentry_telegram/plugin.py
@@ -10,6 +10,8 @@ from sentry_plugins.base import CorePluginMixin
 from sentry.http import safe_urlopen, SafeSession
 from sentry.utils.safe import safe_execute
 
+from markdown_strings import esc_format
+
 from . import __version__, __doc__ as package_doc
 
 
@@ -114,13 +116,13 @@ class TelegramNotificationsPlugin(CorePluginMixin, notify.NotificationPlugin):
 
     def build_message(self, group, event):
         the_tags = defaultdict(lambda: '[NA]')
-        the_tags.update({k:v for k, v in event.tags})
+        the_tags.update({k:esc_format(v) for k, v in event.tags})
         names = {
-            'title': event.title,
+            'title': esc_format(event.title),
             'tag': the_tags,
-            'message': event.message,
-            'project_name': group.project.name,
-            'url': group.get_absolute_url(),
+            'message': esc_format(event.message),
+            'project_name': esc_format(group.project.name),
+            'url': esc_format(group.get_absolute_url()),
         }
 
         template = self.get_message_template(group.project)

--- a/tox.ini
+++ b/tox.ini
@@ -13,4 +13,5 @@ deps =
     pytest-cov>=2.5.1,<2.6.0
     redis==2.10.5
     betamax
+    requests[socks]
 commands = pytest --cov sentry_telegram --cov-config .coveragerc --cov-report xml

--- a/tox.ini
+++ b/tox.ini
@@ -14,4 +14,5 @@ deps =
     redis==2.10.5
     betamax
     requests[socks]
+    markdown-strings==2.1.3
 commands = pytest --cov sentry_telegram --cov-config .coveragerc --cov-report xml


### PR DESCRIPTION
Added proxy support.
Reworked notify method, don't know why. Just seen it in other plugins.
Escaped markdown characters. That's important, because if you have project name with underscore character (like "backend_dev"), it will break Markdown syntax, and Telegram will return error. Used markdown-strings==2.1.3, because newer versions doesn't work properly.