### PR TITLE
Django 4x/5x support

### DIFF
--- a/sentry_telegram/plugin.py
+++ b/sentry_telegram/plugin.py
@@ -3,7 +3,7 @@ import logging
 from collections import defaultdict
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from sentry.plugins.bases import notify
 from sentry.http import safe_urlopen


### PR DESCRIPTION
As Sentry has updated from Django 3x to Django 4x (https://github.com/getsentry/sentry/commit/4a058135bd01c1545fc1ea975f552cb220d805dc) recently, and then to Django 5x (https://github.com/getsentry/sentry/commit/c4dc41d101d5e64c0e9f46c8d4f5bb77c3fd20aa) we meet a problem:

```python
Failed to load plugin 'sentry_telegram':
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/sentry/runner/initializer.py", line 44, in register_plugins
    plugin = ep.load()
             ^^^^^^^^^
  File "/usr/local/lib/python3.11/importlib/metadata/__init__.py", line 202, in load
    module = import_module(match.group('module'))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/usr/local/lib/python3.11/site-packages/sentry_telegram/plugin.py", line 6, in <module>
    from django.utils.translation import ugettext_lazy as _
ImportError: cannot import name 'ugettext_lazy' from 'django.utils.translation' (/usr/local/lib/python3.11/site-packages/django/utils/translation/__init__.py)
```

The reason is that Django has removed ugettext_lazy() function in 4.0 version (https://docs.djangoproject.com/en/5.0/internals/deprecation/#deprecation-removed-in-4-0).
